### PR TITLE
Release v1.0.10 - Update Android SDK to 2.13.1

### DIFF
--- a/yuno-flutter-qa-app/pubspec.yaml
+++ b/yuno-flutter-qa-app/pubspec.yaml
@@ -1,7 +1,7 @@
 name: example
 description: "A new Flutter project."
 publish_to: 'none'
-version: 1.0.9+1
+version: 1.0.10+1
 
 environment:
   sdk: '>=3.5.0 <4.0.0'

--- a/yuno_sdk/android/build.gradle
+++ b/yuno_sdk/android/build.gradle
@@ -92,7 +92,7 @@ dependencies {
     implementation 'androidx.compose.material:material:1.8.0'
     implementation 'androidx.compose.runtime:runtime:1.8.0'
     implementation "androidx.activity:activity-compose:1.10.1"
-    implementation "com.yuno.payments:android-sdk:2.13.0"
+    implementation "com.yuno.payments:android-sdk:2.13.2"
     implementation "androidx.appcompat:appcompat:1.6.1"
     testImplementation("org.jetbrains.kotlin:kotlin-test")
     testImplementation("org.mockito:mockito-core:5.2.0")

--- a/yuno_sdk/pubspec.yaml
+++ b/yuno_sdk/pubspec.yaml
@@ -1,6 +1,6 @@
 name: yuno
 description: "Yuno Flutter SDK empowers you to create seamless payment experiences in your native Android and iOS apps built with Flutter. "
-version: 1.0.9
+version: 1.0.10
 homepage: https://www.y.uno/
 environment:
   sdk: '>=3.6.0 <4.0.0'


### PR DESCRIPTION
## Summary

- Bump Android SDK from `2.13.0` to `2.13.1`
- Bump Flutter SDK version from `1.0.9` to `1.0.10`

## What's in Android SDK 2.13.1

- **Loader timeout fix**: `YunoLoaderComponent` timer now resets when `showPaymentLoading(true)` is called again with `KeepLoaderBridge` active. Previously, the 60s timer from `startPayment` continued counting through `continuePayment`, killing the Activity before the 3DS screen could render.

## Test plan

- [ ] Google Pay + Tap Payments with 3DS redirect → 3DS screen renders correctly
- [ ] Card payment without 3DS → normal flow unaffected
- [ ] PIX/Boleto flows → WebSocket reconnection works

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk version/dependency bumps only; behavior changes come solely from pulling in `com.yuno.payments:android-sdk` `2.13.2`.
> 
> **Overview**
> Bumps the Flutter package/app versions to `1.0.10` (QA app `1.0.10+1`, SDK `1.0.10`).
> 
> Updates the Android native dependency `com.yuno.payments:android-sdk` from `2.13.0` to `2.13.2` in `yuno_sdk/android/build.gradle`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7547aa4c631b03aa8ad228013e74ed1b64ef2226. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->