### PR TITLE
Enrich CLAUDE.md with concrete agent-actionable content

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,69 +2,199 @@
 
 ## What is this repo?
 
-Monorepo del **Yuno Flutter SDK** (`yuno` en pub.dev). Permite integrar pagos nativos (Android/iOS) en apps Flutter. Wrappea los SDKs nativos de Yuno (Android SDK 2.13.0, iOS SDK 2.14.0).
+Monorepo of the **Yuno Flutter SDK** (`yuno` on pub.dev). Wraps the Yuno native SDKs (Android + iOS) and exposes a single Dart API so Flutter apps can run native payment flows (card, APMs, enrollment, seamless, render, headless).
 
-## Estructura del repo
-
-```
-yuno_sdk/           # Paquete principal del SDK (se publica como "yuno" en pub.dev)
-  ├── lib/src/
-  │   ├── channels/       # Method channels (comunicación Flutter <-> nativo)
-  │   ├── platform_interface/  # Capa de abstracción de plataforma
-  │   └── widgets/        # Widgets públicos (YunoPaymentMethods, listeners)
-  ├── android/            # Implementación nativa Android (Kotlin)
-  ├── ios/                # Implementación nativa iOS (Swift)
-  └── test/               # Tests unitarios
-example/            # App de ejemplo básica
-yuno-flutter-qa-app/  # App QA con todas las features (Riverpod, Firebase)
-melos.yaml          # Configuración del monorepo
-```
-
-## Arquitectura del SDK
+## Repo structure
 
 ```
-API pública (Yuno class) → Platform Interface → Method Channels → Nativo (Kotlin/Swift)
+yuno-sdk-flutter/
+├── yuno_sdk/                         # Main package — published as "yuno" on pub.dev
+│   ├── lib/src/
+│   │   ├── channels/                 # Dart <-> native bridge
+│   │   │   └── yuno_channels.dart    # `Yuno` public API + MethodChannel impl
+│   │   ├── platform_interface/       # PlatformInterface abstraction + per-feature folders
+│   │   │   ├── yuno_platform.dart    # Base abstract class
+│   │   │   ├── yuno_method_channel.dart
+│   │   │   ├── init/                 # <feature>/{<feature>.dart, models/, parsers.dart, keys/}
+│   │   │   ├── start_payment/
+│   │   │   ├── start_payment_lite/
+│   │   │   ├── enrollment_payments/
+│   │   │   ├── seamless/
+│   │   │   └── show_payment_methods/
+│   │   └── widgets/                  # YunoPaymentMethods, YunoPaymentListener, ...
+│   ├── android/                      # Native Android plugin (Kotlin)
+│   ├── ios/                          # Native iOS plugin (Swift)
+│   └── test/                         # Unit + widget tests (mocktail)
+├── example/                          # Minimal demo app
+├── yuno-flutter-qa-app/              # Full-featured QA app (Riverpod + Firebase)
+├── melos.yaml                        # Monorepo scripts
+└── CHANGELOG.md                      # Release history
 ```
 
-- **Clase principal:** `Yuno` en `yuno_sdk/lib/src/channels/yuno_channels.dart`
-- **Métodos clave:** `init()`, `startPayment()`, `startPaymentLite()`, `enrollmentPayment()`, `continuePayment()`, `startPaymentSeamlessLite()`
-- **Widgets:** `YunoPaymentMethods`, `YunoPaymentListener`, `YunoEnrollmentListener`, `YunoMultiListener`
-- **Extension en BuildContext:** `context.startPayment(...)`, `context.startPaymentLite(...)`, etc.
+## Architecture
 
-## Distribución
+```
+┌──────────────────────────────────────────┐
+│  Merchant Flutter App                    │
+└──────────────┬───────────────────────────┘
+               │ Yuno.init(), Yuno.startPayment(), ...
+               ▼
+┌──────────────────────────────────────────┐
+│  Public API (Yuno class)                 │  yuno_channels.dart
+└──────────────┬───────────────────────────┘
+               ▼
+┌──────────────────────────────────────────┐
+│  YunoPlatform (PlatformInterface)        │  yuno_platform.dart
+│    └── YunoMethodChannel (default impl)  │
+└──────────────┬───────────────────────────┘
+               │ MethodChannel("yuno/payments")
+               ▼
+┌────────────────────────┬─────────────────┐
+│  Android (Kotlin)      │  iOS (Swift)    │
+│  YunoSdkAndroidPlugin  │  YunoSdkFoundationPlugin
+│  + per-feature handlers│  + per-feature handlers
+└────────────────────────┴─────────────────┘
+```
 
-- Se publica en **pub.dev** como paquete `yuno`
-- Instalación: `flutter pub add yuno`
-- Plataformas: Android (SDK 21+), iOS (14.0+)
-- Requiere Dart >=3.6.0, Flutter >=3.3.0
+Channel name: `"yuno/payments"`. Method keys (raw strings, must match across Dart/Kotlin/Swift):
+`initialize`, `startPayment`, `startPaymentLite`, `continuePayment`, `enrollmentPayment`, `startPaymentSeamless`, `receiveDeeplink`, `hideLoader`, `showPaymentMethods`.
 
-## Integración típica
+## Public API — what merchants use
 
-1. Agregar dependencia: `yuno: ^1.0.5`
-2. Llamar `Yuno.init(apiKey, countryCode, config)` al inicio
-3. Usar `YunoPaymentMethods` widget para mostrar métodos de pago
-4. Llamar `Yuno.startPayment()` o `context.startPayment()` para iniciar flujo
-5. Escuchar resultados con `YunoPaymentListener`
+- **`Yuno` class** (`lib/src/channels/yuno_channels.dart`):
+  `init()`, `startPayment()`, `startPaymentLite()`, `enrollmentPayment()`, `continuePayment()`, `startPaymentSeamlessLite()`, `showPaymentMethods()`, `receiveDeeplink()`, `hideLoader()`.
+- **Widgets** (`lib/src/widgets/`): `YunoPaymentMethods`, `YunoPaymentListener`, `YunoEnrollmentListener`, `YunoMultiListener`, `YunoReader`.
+- **BuildContext extensions**: `context.startPayment(...)`, `context.startPaymentLite(...)`, etc.
 
-## Comandos útiles
+## Native sync (the tricky part)
+
+This SDK **wraps** the native SDKs — pinning is manual and lags slightly.
+
+| Platform | Version pin | File |
+|---|---|---|
+| Android native | **2.13.4** | `yuno_sdk/android/build.gradle` (dep `"com.yuno.payments:android-sdk:2.13.4"`) |
+| iOS native | **2.14.1** | `yuno_sdk/ios/yuno.podspec` (`s.dependency 'YunoSDK', '2.14.1'`) |
+
+Companion repos (local dev):
+- Android → `/Users/vlass/Documents/SDKS/yuno-android-sdk` (currently on `release/2.15.0`)
+- iOS → `/Users/vlass/Documents/SDKS/yuno-ios`
+
+**When bumping a native version:**
+1. Bump the version string in `build.gradle` (Android) or `yuno.podspec` (iOS).
+2. Run `melos bootstrap` to refresh the example and QA app pods.
+3. Smoke-test both `example/` and `yuno-flutter-qa-app/` on each platform.
+4. Add an entry to `CHANGELOG.md`.
+5. Bump `pubspec.yaml` version.
+
+## Per-feature file pattern (native handlers)
+
+Every method channel method has 4 parallel implementations:
+
+| Layer | Location | Example for `startPayment` |
+|---|---|---|
+| Dart public API | `lib/src/channels/yuno_channels.dart` | `Future<void> startPayment(...)` |
+| Dart platform interface | `lib/src/platform_interface/start_payment/` | `start_payment.dart`, `models/start_payment_model.dart`, `models/parsers.dart`, `keys/` |
+| Android handler | `yuno_sdk/android/src/main/kotlin/.../handlers/` | `StartPaymentHandler.kt` |
+| iOS handler | `yuno_sdk/ios/Classes/` | `YunoMethods.swift` → `startPayment(...)`, model in `Models/StartPayment.swift` |
+
+**Rule**: keys/model shape must stay in sync across all 4 layers. If you rename a key, grep the whole repo.
+
+## Adding a new native method — step-by-step
+
+1. **Define the key** as a constant in `lib/src/platform_interface/<feature>/keys/` (Dart).
+2. **Define the model** (Dart data class + `toMap()/fromMap()` in `models/`).
+3. **Expose in `YunoPlatform`** (abstract method) + implement in `YunoMethodChannel`.
+4. **Add to public `Yuno` class** (`channels/yuno_channels.dart`) forwarding to `YunoPlatform.instance`.
+5. **Android handler**: new file under `android/src/main/kotlin/.../handlers/`. Register in `YunoSdkAndroidPlugin.kt`'s `onMethodCall` dispatch.
+6. **iOS handler**: add case in `YunoSdkFoundationPlugin.swift`'s method handler, implement in `YunoMethods.swift` or a new feature file.
+7. **Unit test** in `yuno_sdk/test/` using `MockYunoPlatform` (see `test/mock_yuno_platform.dart`).
+8. **Smoke-test** in `example/` and/or `yuno-flutter-qa-app/`.
+
+## Dart conventions
+
+- `analysis_options.yaml` uses `package:flutter_lints/flutter.yaml` (strict defaults).
+- Null safety on (Dart `>=3.6.0 <4.0.0`, Flutter `>=3.3.0`).
+- Every feature has: **handler + models + parsers + keys** as separate files.
+- Platform-interface plugin: `plugin_platform_interface: ^2.1.8`.
+
+### Code rules
+- **No `!` force-unwraps** — use `??`, `?.`, early returns, or `ArgumentError` with context.
+- **Never swallow errors** from native — surface via `PlatformException` → map to domain error.
+- **Raw channel keys** (e.g., `"startPayment"`) must live in `keys/` files, not inlined.
+- **Models are immutable** (`final` fields, `const` constructors where possible).
+- **Prefer extension methods on `BuildContext`** for merchant-facing ergonomics.
+
+## Tests
+
+Located in `yuno_sdk/test/`. Stack: `flutter_test` + **mocktail**.
+
+| File | Purpose |
+|---|---|
+| `yuno_channels_test.dart` | Method channel calls (happy path + errors) |
+| `mock_yuno_platform.dart` | Mock implementation of `YunoPlatform` |
+| `yuno_payment_listener_test.dart`, `yuno_enrollment_listener_test.dart`, `yuno_payment_methods_test.dart`, `yuno_multi_listener_test.dart` | Widget tests |
+
+**Test policy:**
+- DO test: method channel contracts, models (`toMap`/`fromMap`), parsers, widget public API.
+- DON'T test: native internals (tested in the native repos), Flutter framework behavior.
+
+## Melos scripts (`melos.yaml`)
 
 ```bash
-# Setup inicial
-./setup_local.sh
-melos bootstrap
-
-# Tests
-melos run test          # Tests con cobertura
-
-# Calidad de código
-melos run format        # Formatear
-melos run analyze       # Análisis estático
+melos bootstrap         # Install deps + link local packages
+melos run test          # Run flutter test --coverage, generate HTML, open on macOS
+melos run bitrise_test  # Same pipeline for CI
 ```
 
-## Convenciones
+No built-in format/analyze scripts — run directly in the package:
+```bash
+cd yuno_sdk && dart format . && flutter analyze
+```
 
-- Monorepo gestionado con **Melos**
-- Tests con **mocktail**
-- Branch principal: `master`
-- PRs siguen template en `.github/PULL_REQUEST_TEMPLATE.md`
-- Cada feature nativa tiene: handler, models, parsers, keys
+## Example vs QA app
+
+| App | Purpose |
+|---|---|
+| `example/` | Minimal demo (environments + main screen). Used for smoke tests and pub.dev example. |
+| `yuno-flutter-qa-app/` | Full QA: Riverpod state, Firebase, country picker, color picker, shared preferences, app links. Used by QA team to exercise every integration mode. |
+
+## Git / PRs / Release
+
+- **Main branch**: `master` — PRs merge here.
+- **PR template**: `.github/PULL_REQUEST_TEMPLATE.md` requires Purpose, Description, Related Issue, Checklist, Screenshots, Type (bug/feature/breaking/refactor/docs).
+- **Commit style** (from recent history): plain-English descriptions, semver-aware. Example: `"update Android SDK to 2.13.4 and bump Flutter SDK to 1.0.12"`.
+- **CI**: `.github/workflows/dependabot.yml` only (no custom CI workflow yet — tests run locally / via Melos).
+- **Release**:
+  1. Bump native versions (see "Native sync" above).
+  2. Bump `yuno_sdk/pubspec.yaml` `version:`.
+  3. Update `CHANGELOG.md`.
+  4. Tag + push.
+  5. `flutter pub publish` from `yuno_sdk/`.
+  6. Verify at https://pub.dev/packages/yuno.
+
+## Common pitfalls
+
+- **Bumping native**: the `example/` Podfile and `yuno-flutter-qa-app/` might cache pods. After bumping iOS pod version, `cd example/ios && pod install --repo-update`.
+- **Channel-key drift**: adding a method on Dart side but forgetting Android/iOS → silent `MissingPluginException` at runtime. Always ship all 4 layers in the same PR.
+- **Android handler lifecycle**: `YunoSdkAndroidPlugin` implements `ActivityAware` + `DefaultLifecycleObserver`. Handlers that launch activities need the attached Activity reference — don't call from `onAttachedToEngine` directly.
+- **iOS deeplinks**: must be routed via `Yuno.receiveDeeplink()` from the merchant's `AppDelegate` or the iOS payment flow hangs.
+
+## Quick reference
+
+| Task | Command / File |
+|---|---|
+| Bootstrap workspace | `melos bootstrap` |
+| Run tests | `melos run test` |
+| Format | `dart format yuno_sdk/` |
+| Analyze | `cd yuno_sdk && flutter analyze` |
+| Bump Android native | `yuno_sdk/android/build.gradle` line with `"com.yuno.payments:android-sdk:X.Y.Z"` |
+| Bump iOS native | `yuno_sdk/ios/yuno.podspec` `s.dependency 'YunoSDK', 'X.Y.Z'` |
+| Publish | `cd yuno_sdk && flutter pub publish` |
+
+## Current versions (as of 2026-04-24)
+
+- **Flutter SDK (this package)**: 1.0.12
+- **Android native pinned**: 2.13.4
+- **iOS native pinned**: 2.14.1
+- **Dart**: `>=3.6.0 <4.0.0`
+- **Flutter**: `>=3.3.0`


### PR DESCRIPTION
## Purpose
Replace the lightweight CLAUDE.md (intro-style, ~70 lines) with an agent-actionable guide (~180 lines) that documents the repo's real conventions and workflows.

## Description
- Architecture diagram (Dart → PlatformInterface → Channels → Native)
- Exact method channel name (\`yuno/payments\`) and method key list
- Native sync table with pinned versions + bump steps
- Per-feature 4-layer file pattern (Dart API / PlatformInterface / Android / iOS) with concrete examples
- Step-by-step guide for adding a new native method
- Dart code rules and test policy
- Melos scripts, git flow, release process (including \`flutter pub publish\`)
- Common pitfalls (lifecycle, deeplinks, pod cache, channel-key drift)
- Quick reference commands table

## Type
- [x] Documentation

## Checklist
- [x] No code changes — docs only
- [x] No breaking changes
- [x] Version pins match current \`build.gradle\` / \`yuno.podspec\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: documentation-only changes with no runtime, API, or build impact.
> 
> **Overview**
> Replaces the brief `CLAUDE.md` with a much more detailed, English, *agent-actionable* guide covering repo structure, the Dart→PlatformInterface→MethodChannel→native architecture, and the exact channel name and method key list.
> 
> Adds concrete workflows for native SDK version pinning/bumping, the 4-layer per-feature implementation pattern, steps for adding new native methods, coding/testing conventions, and release/CI quick-reference plus common integration pitfalls.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2baaa29cf8ad7d95a8da848642d53a4ef7e98f6c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->