### PR TITLE
fix changelog error messahe

### DIFF
--- a/Dangerfile
+++ b/Dangerfile
@@ -2,6 +2,6 @@
 changelog_modified = git.modified_files.include?("yuno_sdk/CHANGELOG.md")
 
 unless changelog_modified
-  markdown("I see `yuno_sdk/CHANGELOG.md` is still untouched. Curious, considering your PR clearly changes things. :thinking: Before merging, spare us 30 seconds and document what you did .. Your future self will thank you. Ours will too.")
-  fail("Changelog not updated!. Please remember to follow the changelog template: `[TICKET-NUMBER](TICKET-URL) | YYYY/MM/DD | Description of changes`.")
+  markdown("I see `yuno_sdk/CHANGELOG.md` is still untouched. Curious, considering your PR clearly changes things. :thinking: Heads up: this file is published to pub.dev as the package changelog, so customers will read it. Before merging, spare us 30 seconds and document what you did in user-facing terms (no ticket IDs, no internal jargon). Your future self will thank you. Ours will too.")
+  fail("Changelog not updated! Please add an entry under the new version using the existing format: `- feat: <user-facing description>` for new features, `- fix: <user-facing description>` for bug fixes. Remember this file is public on pub.dev — avoid ticket IDs, internal flag names, or implementation details.")
 end


### PR DESCRIPTION
# 🌟 Pull Request

## 🎯 Purpose

<!-- Why is this pull request needed? -->
- 

## 📝 Description

<!-- Please describe your changes in detail -->
- 

## 🔗 Related Issue

<!-- If this PR addresses an issue, link to it here -->
Closes #

## 📋 Checklist

- [ ] ✅ My code follows the code style of this project.
- [ ] 📝 I have commented my code, particularly in hard-to-understand areas.
- [ ] 🐛 I have fixed all new and existing tests.
- [ ] 📄 I have updated the documentation accordingly.
- [ ] 📦 This change requires a documentation update.

## 💡 Additional Information

<!-- Any additional information or context -->
- 

## 🚀 Screenshots (if applicable)

<!-- If your PR includes UI changes, you can include screenshots here -->
- 

## 🧩 Types of Changes

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🔨 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🛠 Refactoring (change that doesn't add functionality but improves code quality)
- [ ] 📚 Documentation update

## 🔍 Reviewers

<!-- Tag relevant team members for review -->
@reviewer1 @reviewer2 @reviewer3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only updates Dangerfile warning/error text; no runtime or SDK logic changes. Low risk aside from slightly changing CI guidance for contributors.
> 
> **Overview**
> Updates the Danger changelog check to provide clearer, more user-facing guidance when `yuno_sdk/CHANGELOG.md` isn’t modified.
> 
> The `markdown`/`fail` messages now emphasize that the changelog is published to pub.dev and instruct contributors to use `- feat:`/`- fix:` entries while avoiding ticket IDs and internal jargon.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 67a61c4e64c73d503cee9878ee6867e5f2333ac7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->