### PR TITLE
update Android SDK to 2.15.1 and bump Flutter SDK to 1.0.14

### DIFF
--- a/yuno-flutter-qa-app/pubspec.yaml
+++ b/yuno-flutter-qa-app/pubspec.yaml
@@ -1,7 +1,7 @@
 name: example
 description: "A new Flutter project."
 publish_to: 'none'
-version: 1.0.13+1
+version: 1.0.14+1
 
 environment:
   sdk: '>=3.5.0 <4.0.0'

--- a/yuno_sdk/CHANGELOG.md
+++ b/yuno_sdk/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 1.0.14
+- fix: update native Android SDK to 2.15.1
+
 ## 1.0.13
 - feat: update native Android SDK to 2.15.0
 - feat: update native iOS SDK to 2.16.0

--- a/yuno_sdk/android/build.gradle
+++ b/yuno_sdk/android/build.gradle
@@ -92,7 +92,7 @@ dependencies {
     implementation 'androidx.compose.material:material:1.8.0'
     implementation 'androidx.compose.runtime:runtime:1.8.0'
     implementation "androidx.activity:activity-compose:1.10.1"
-    implementation "com.yuno.payments:android-sdk:2.15.0"
+    implementation "com.yuno.payments:android-sdk:2.15.1"
     implementation "androidx.appcompat:appcompat:1.6.1"
     testImplementation("org.jetbrains.kotlin:kotlin-test")
     testImplementation("org.mockito:mockito-core:5.2.0")

--- a/yuno_sdk/ios/yuno.podspec
+++ b/yuno_sdk/ios/yuno.podspec
@@ -4,7 +4,7 @@
 #
 Pod::Spec.new do |s|
   s.name             = 'yuno'
-  s.version          = '1.0.13'
+  s.version          = '1.0.14'
   s.summary          = 'A Yuno project'
   s.description      = <<-DESC
 A new Flutter plugin project.

--- a/yuno_sdk/pubspec.yaml
+++ b/yuno_sdk/pubspec.yaml
@@ -1,6 +1,6 @@
 name: yuno
 description: "Yuno Flutter SDK empowers you to create seamless payment experiences in your native Android and iOS apps built with Flutter. "
-version: 1.0.13
+version: 1.0.14
 homepage: https://www.y.uno/
 environment:
   sdk: '>=3.6.0 <4.0.0'


### PR DESCRIPTION
## Purpose
Hotfix release of the Yuno Flutter SDK that picks up the native Android `2.15.1` patch.

## Description
- Bumps `com.yuno.payments:android-sdk` from `2.15.0` to `2.15.1` in `yuno_sdk/android/build.gradle`.
- Bumps `yuno` package version from `1.0.13` to `1.0.14`.
- Bumps `yuno-flutter-qa-app` version from `1.0.13+1` to `1.0.14+1`.
- Adds `1.0.14` entry to `yuno_sdk/CHANGELOG.md`.
- iOS pin unchanged (`2.16.0`).

## Related Issue
YSHUB-4619 — crash caused by Flutter plugin lifecycle incompatibility with the Android SDK on process death.

Cherry of native fix:
- yuno-payments/android-sdk#1679 (EnvMode crash on process death)
- yuno-payments/android-sdk#1681 (YunoConfig null crash, follow-up)

## Type
- [x] Bug fix

## Checklist
- [x] Native pin bumped (Android)
- [x] Package version bumped
- [x] QA app version bumped
- [x] Changelog updated
- [ ] `melos bootstrap` + smoke test on `example/` and `yuno-flutter-qa-app/`
- [ ] After merge: tag + `flutter pub publish` from `yuno_sdk/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes the pinned native Android payments SDK version, which can affect runtime/payment flows, though the PR is otherwise just version/changelog bumps.
> 
> **Overview**
> Publishes a `1.0.14` hotfix of the Flutter plugin by bumping versions across `yuno_sdk` (pubspec + podspec) and the QA app.
> 
> Updates the Android dependency pin from `com.yuno.payments:android-sdk:2.15.0` to `2.15.1` and records the change in `CHANGELOG.md`; iOS native pin remains unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f257650e2f997f98f4a08a8efde0253ce7e8f427. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->