### PR TITLE
fix: Android OTT not returned after native SDK 2.15.0 bump

### DIFF
--- a/yuno-flutter-qa-app/ios/Flutter/AppFrameworkInfo.plist
+++ b/yuno-flutter-qa-app/ios/Flutter/AppFrameworkInfo.plist
@@ -20,5 +20,7 @@
   <string>????</string>
   <key>CFBundleVersion</key>
   <string>1.0</string>
+  <key>MinimumOSVersion</key>
+  <string>14.0</string>
 </dict>
 </plist>

--- a/yuno-flutter-qa-app/ios/Runner/AppDelegate.swift
+++ b/yuno-flutter-qa-app/ios/Runner/AppDelegate.swift
@@ -2,15 +2,12 @@ import Flutter
 import UIKit
 
 @main
-@objc class AppDelegate: FlutterAppDelegate, FlutterImplicitEngineDelegate {
+@objc class AppDelegate: FlutterAppDelegate {
   override func application(
     _ application: UIApplication,
     didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
   ) -> Bool {
+    GeneratedPluginRegistrant.register(with: self)
     return super.application(application, didFinishLaunchingWithOptions: launchOptions)
-  }
-
-  func didInitializeImplicitFlutterEngine(_ engineBridge: FlutterImplicitEngineBridge) {
-    GeneratedPluginRegistrant.register(with: engineBridge.pluginRegistry)
   }
 }

--- a/yuno-flutter-qa-app/pubspec.yaml
+++ b/yuno-flutter-qa-app/pubspec.yaml
@@ -1,7 +1,7 @@
 name: example
 description: "A new Flutter project."
 publish_to: 'none'
-version: 1.0.14+1
+version: 1.0.15+1
 
 environment:
   sdk: '>=3.5.0 <4.0.0'

--- a/yuno_sdk/CHANGELOG.md
+++ b/yuno_sdk/CHANGELOG.md
@@ -1,27 +1,37 @@
+## 1.0.15
+
+- fix: Android one-time token (OTT) was not returned to the app after `startPayment`/`startPaymentLite` when running on native Android SDK 2.15.0 or newer
+
 ## 1.0.14
+
 - fix: update native Android SDK to 2.15.1
 
 ## 1.0.13
+
 - feat: update native Android SDK to 2.15.0
 - feat: update native iOS SDK to 2.16.0
 
 ## 1.0.12
+
 - feat: update native Android SDK to 2.13.4
 - feat: add cross-platform appearance support via `YunoConfig.appearance`
 - feat: Android font resolution normalizes font names automatically (e.g. "Dancing Script" resolves to "dancingscript" resource)
 - feat: platform-specific configs (`IosConfig.appearance` / `AndroidConfig.appearance`) take priority over shared `YunoConfig.appearance`
 
 ## 1.0.9
+
 - feat: update native Android SDK to 2.13.0
 - feat: update native iOS SDK to 2.14.1
 - feat: add language support for Hindi, Bengali, Malayalam, and Urdu
 
 ## 1.0.5
+
 - fix: Button colors appearing as clear/transparent when not explicitly configured
 - fix: Update yuno_sdk_platform_interface to ^0.7.2
 - fix: Update yuno_sdk_foundation to ^1.0.5
 
 ## 1.0.4
+
 - fix: Update all dependencies to resolve conflicts
 - fix: Update yuno_sdk_core to ^0.4.0
 - fix: Update yuno_sdk_platform_interface to ^0.7.1
@@ -29,33 +39,42 @@
 - fix: Update yuno_sdk_foundation to ^1.0.4
 
 ## 1.0.3
+
 - feat: update native Android SDK to 2.10.0
 - feat: update native iOS SDK to 2.11.1
 - feat: update yuno_sdk_platform_interface to 0.7.0
 
 ## 1.0.2
+
 - feat: update native Android SDK to 2.8.1
 - feat: update native iOS SDK to 2.9.0
 - fix: support Kotlin 2.x and Compose Compiler plugin compatibility on Android
 
 ## 1.0.1
+
 - fix: Update Android native SDK to 2.6.5 (corrects version from 1.0.0)
 
 ## 1.0.0
+
 - feat: upgrade native sdks
 
 ## 0.9.1
+
 - feat: upgrade native sdks
 
 ## 0.8.0
- - feat: upgrade native sdks
+
+- feat: upgrade native sdks
 
 ## 0.7.1
-  - fix: upgrade yuno_sdk_platform_interfaces
+
+- fix: upgrade yuno_sdk_platform_interfaces
+
 ## 0.7.0
+
 - fix: grammar error
 
-    Instead of:
+  Instead of:
 
   ```dart
     var status = YunoStatus.succeded
@@ -66,33 +85,50 @@
   ```dart
    var status = YunoStatus.succeeded
   ```
+
 - feat: Yuno SDK upgraded
 - feat: Readme Updated
+
 ## 0.6.0
+
 - feat: Yuno SDK upgrade
+
 ## 0.5.1
+
 - fix: Upgrade yuno_sdk_foundation_package
+
 ## 0.5.0
+
 - feat: Yuno SDK Seamless Supported for Android & iOS
 - feat: Code improvements
 - feat: Upgrade Dart SDK
 - fix: Upgrade pro-guard rules for Android
+
 ## 0.4.1
+
 - bugFix: Valuenotifier did not update OTT in IOS
+
 ## 0.4.0
+
 - feat: README improvements
 - feat: Native SDKs upgraded
 - feat: Yuno platform interface testing
+
 ## 0.3.0
+
 - feat: Readme updated
 - feat: Code improvements
 - feat: Coverage 98.7%
 - feat: Native Android and IOS SDK's Upgraded to 1.19.0 version
 - fix: On Android, the ProGuard rules were updated to resolve issues encountered when generating APK's or AAB's in release mode.
+
 ## 0.2.0
+
 - feat: enrollment support for android
 - fix: documentation
+
 ## 0.1.0 - Android & IOS
+
 - feat: Yuno initialization
 - feat: Yuno start checkout
 - feat: Yuno start payment lite

--- a/yuno_sdk/CHANGELOG.md
+++ b/yuno_sdk/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 1.0.15
 
 - fix: Android one-time token (OTT) was not returned to the app after `startPayment`/`startPaymentLite` when running on native Android SDK 2.15.0 or newer
+- fix: Android payment status was not delivered after `continuePayment` when running on native Android SDK 2.15.0 or newer
 
 ## 1.0.14
 

--- a/yuno_sdk/android/build.gradle
+++ b/yuno_sdk/android/build.gradle
@@ -92,7 +92,7 @@ dependencies {
     implementation 'androidx.compose.material:material:1.8.0'
     implementation 'androidx.compose.runtime:runtime:1.8.0'
     implementation "androidx.activity:activity-compose:1.10.1"
-    implementation "com.yuno.payments:android-sdk:2.15.1"
+    implementation "com.yuno.payments:android-sdk:2.17.1"
     implementation "androidx.appcompat:appcompat:1.6.1"
     testImplementation("org.jetbrains.kotlin:kotlin-test")
     testImplementation("org.mockito:mockito-core:5.2.0")

--- a/yuno_sdk/android/src/main/kotlin/com/yuno_flutter/yuno_sdk_android/YunoSdkAndroidPlugin.kt
+++ b/yuno_sdk/android/src/main/kotlin/com/yuno_flutter/yuno_sdk_android/YunoSdkAndroidPlugin.kt
@@ -109,7 +109,8 @@ If you continue to have trouble, follow this discussion to get some support """,
                     call = call,
                     result = result,
                     context = context,
-                    activity = activity
+                    activity = activity,
+                    onState = this::onPaymentStateChange,
                 )
             }
             Key.enrollmentPayment -> {

--- a/yuno_sdk/android/src/main/kotlin/com/yuno_flutter/yuno_sdk_android/YunoSdkAndroidPlugin.kt
+++ b/yuno_sdk/android/src/main/kotlin/com/yuno_flutter/yuno_sdk_android/YunoSdkAndroidPlugin.kt
@@ -88,7 +88,9 @@ If you continue to have trouble, follow this discussion to get some support """,
                 init.handler(
                     call = call,
                     result = result,
-                    context = context, activity,
+                    context = context,
+                    activity = activity,
+                    onOtt = this::onTokenUpdated,
                 )
             }
             Key.startPaymentLite -> {
@@ -97,7 +99,8 @@ If you continue to have trouble, follow this discussion to get some support """,
                         call = call,
                         result = result,
                         context = context,
-                        activity = activity
+                        activity = activity,
+                        onOtt = this::onTokenUpdated,
                     )
             }
             Key.continuePayment -> {

--- a/yuno_sdk/android/src/main/kotlin/com/yuno_flutter/yuno_sdk_android/features/continue_payment/method_channel/ContinuePaymentHandler.kt
+++ b/yuno_sdk/android/src/main/kotlin/com/yuno_flutter/yuno_sdk_android/features/continue_payment/method_channel/ContinuePaymentHandler.kt
@@ -13,17 +13,18 @@ class ContinuePaymentHandler {
         private const val TAG = "ContinuePaymentHandler"
     }
     
-    fun handler(call: MethodCall, result: Result, context: Context, activity: FlutterFragmentActivity){
+    fun handler(call: MethodCall, result: Result, context: Context, activity: FlutterFragmentActivity, onState: (String?, String?) -> Unit){
        try {
            val showPaymentStatus = call.arguments<Boolean>() ?: true
-           
+
            // Get current saved value before updating
            val previousShowPaymentStatus = PaymentConfig.getShowPaymentStatus()
-           
+
            // Save the showPaymentStatus value in memory for later use in deeplink handling
            PaymentConfig.setShowPaymentStatus(showPaymentStatus)
-           
-           activity.continuePayment(showPaymentStatus = showPaymentStatus)
+
+           // Re-register the payment-state callback per call: Yuno.init() clears it via clearPaymentFlowCallbacks() (native SDK >= 2.14.0)
+           activity.continuePayment(showPaymentStatus = showPaymentStatus, callbackPaymentState = onState)
        } catch (e:Exception){
            result.error("4",e.message ?: "Unexpected Error",e.cause)
        }

--- a/yuno_sdk/android/src/main/kotlin/com/yuno_flutter/yuno_sdk_android/features/start_payment/method_channel/StartPaymentHandler.kt
+++ b/yuno_sdk/android/src/main/kotlin/com/yuno_flutter/yuno_sdk_android/features/start_payment/method_channel/StartPaymentHandler.kt
@@ -11,7 +11,7 @@ import io.flutter.plugin.common.MethodCall
 import io.flutter.plugin.common.MethodChannel.Result
 
 class StartPaymentHandler {
-    fun handler(call: MethodCall, result: Result, context: Context, activity: FlutterFragmentActivity){
+    fun handler(call: MethodCall, result: Result, context: Context, activity: FlutterFragmentActivity, onOtt: (String?) -> Unit){
         try {
             val argument = call.arguments<Map<String, Any>>()
             val model = argument?.toStartPayment()
@@ -21,7 +21,8 @@ class StartPaymentHandler {
             // Save the showPaymentStatus for potential deeplink handling
             PaymentConfig.setShowPaymentStatus(showPaymentStatus)
             Yuno.setPlatform(YunoPlatform.FLUTTER)
-            activity.startPayment(showPaymentStatus = showPaymentStatus)
+            // Re-register the OTT callback per payment: Yuno.init() clears it via clearPaymentFlowCallbacks() (native SDK >= 2.14.0)
+            activity.startPayment(showPaymentStatus = showPaymentStatus, callbackOTT = onOtt)
         } catch (e: Exception) {
             return result.error("SOMETHING_WENT_WRONG", "Failure", e.message)
         }

--- a/yuno_sdk/android/src/main/kotlin/com/yuno_flutter/yuno_sdk_android/features/start_payment_lite/method_channels/StartPaymentLiteHandler.kt
+++ b/yuno_sdk/android/src/main/kotlin/com/yuno_flutter/yuno_sdk_android/features/start_payment_lite/method_channels/StartPaymentLiteHandler.kt
@@ -12,7 +12,7 @@ import io.flutter.plugin.common.MethodCall
 import io.flutter.plugin.common.MethodChannel.Result
 
 class StartPaymentLiteHandler {
-    fun handler(call: MethodCall, result: Result, context: Context, activity: FlutterFragmentActivity){
+    fun handler(call: MethodCall, result: Result, context: Context, activity: FlutterFragmentActivity, onOtt: (String?) -> Unit){
         try {
             val argument = call.arguments<Map<String, Any>>()
             val either = argument?.toStartPaymentLite()
@@ -26,12 +26,14 @@ class StartPaymentLiteHandler {
                     countryCode = model.countryCode
                 )
                 Yuno.setPlatform(YunoPlatform.FLUTTER)
+                // Re-register the OTT callback per payment: Yuno.init() clears it via clearPaymentFlowCallbacks() (native SDK >= 2.14.0)
                 activity.startPaymentLite(
                     paymentSelected = PaymentSelected(
                         paymentMethodType = model.paymentMethodSelected.paymentMethodType,
                         vaultedToken = model.paymentMethodSelected.vaultedToken,
                     ),
-                    showPaymentStatus = model.showPaymentStatus
+                    showPaymentStatus = model.showPaymentStatus,
+                    callbackOTT = onOtt,
                 )
             }?.onFailure { exception ->  return result.error(
                 "5",

--- a/yuno_sdk/ios/yuno.podspec
+++ b/yuno_sdk/ios/yuno.podspec
@@ -4,7 +4,7 @@
 #
 Pod::Spec.new do |s|
   s.name             = 'yuno'
-  s.version          = '1.0.14'
+  s.version          = '1.0.15'
   s.summary          = 'A Yuno project'
   s.description      = <<-DESC
 A new Flutter plugin project.
@@ -15,7 +15,7 @@ A new Flutter plugin project.
   s.source           = { :path => '.' }
   s.source_files = 'Classes/**/*'
   s.dependency 'Flutter'
-  s.dependency 'YunoSDK', '2.16.0'
+  s.dependency 'YunoSDK', '2.18.0'
   s.platform = :ios, '14.0'
   s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES'}
   s.swift_version = '5.0'

--- a/yuno_sdk/pubspec.yaml
+++ b/yuno_sdk/pubspec.yaml
@@ -1,10 +1,10 @@
 name: yuno
 description: "Yuno Flutter SDK empowers you to create seamless payment experiences in your native Android and iOS apps built with Flutter. "
-version: 1.0.14
+version: 1.0.15
 homepage: https://www.y.uno/
 environment:
-  sdk: '>=3.6.0 <4.0.0'
-  flutter: '>=3.3.0'
+  sdk: ">=3.6.0 <4.0.0"
+  flutter: ">=3.3.0"
 
 dependencies:
   flutter:


### PR DESCRIPTION
# 🌟 Pull Request

## 🎯 Purpose

After the native Android SDK was bumped from `2.13.4` → `2.15.0` (Flutter SDK `1.0.13`), the Android **one-time token (OTT) stopped being returned** to Flutter. A full audit of the regression shows the **payment status** was affected by the same root cause. This PR restores both.

## 📝 Description

**Root cause.** The native Android SDK shipped `clearPaymentFlowCallbacks()` in `2.14.0` (`com.yuno.sdk.payments.PaymentsFlow`), invoked from `injectDependencies()` — which runs on **every** `Yuno.initialize()`. It nulls the three payment-flow callbacks:

```kotlin
internal fun clearPaymentFlowCallbacks() {
    merchantOTTCallback = null
    merchantOTTCallBackWithInformation = null
    merchantStateCallback = null
}
```

This function does **not** exist in `2.13.4`. The Flutter plugin registers its callbacks **once**, in `YunoSdkAndroidPlugin.onCreate` via `startCheckout(callbackOTT = …, callbackPaymentState = …)`. Real-world sequence:

1. Native activity created → `onCreate` → `startCheckout(...)` registers `merchantOTTCallback` + `merchantStateCallback`.
2. Dart calls `Yuno.init()` → `InitHandler` → `Yuno.initialize()` → `injectDependencies()` → `clearPaymentFlowCallbacks()` → **both callbacks set to `null`**.
3. The per-flow handlers called the native functions **without re-passing the callbacks**, so they stayed `null`.
4. The token/state is produced and put in the result intent, but delivery is guarded by `merchantOTTCallback?.invoke(...)` / `merchantStateCallback?.invoke(...)` → `null` → **nothing reaches `channel.invokeMethod(...)`**.

The native contract changed: callbacks must be passed on **each** flow call (this is exactly what the native sample app does). The plugin kept the old register-once pattern.

### Full callback audit

| Native callback                      | Flow                                                                                               | Delivered to Dart via  | Re-registerable?                                                                       | Status                                                                           |
| ------------------------------------ | -------------------------------------------------------------------------------------------------- | ---------------------- | -------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------- |
| `merchantOTTCallback`                | `startPayment` / `startPaymentLite`                                                                | `Key.ott`              | yes (`callbackOTT`)                                                                    | **fixed here**                                                                   |
| `merchantStateCallback`              | `continuePayment`                                                                                  | `Key.status`           | yes (`callbackPaymentState`)                                                           | **fixed here**                                                                   |
| `merchantStateCallback`              | `startPaymentSeamlessLite`                                                                         | method result          | yes                                                                                    | already correct (`SeamlessHandler`)                                              |
| `merchantStateCallback`              | `startPayment` / `startPaymentLite` **direct result** (e.g. user cancels before `continuePayment`) | `Key.status`           | **no** — native `startPayment`/`startPaymentLite` do not accept `callbackPaymentState` | **residual gap → needs native change** (see below)                               |
| `merchantOTTCallBackWithInformation` | —                                                                                                  | —                      | —                                                                                      | not used by this plugin                                                          |
| `merchantEnrollmentCallback`         | `enrollment`                                                                                       | `Key.enrollmentStatus` | —                                                                                      | **not affected** — separate var, `clearPaymentFlowCallbacks()` does not touch it |

The Flutter integration model surfaces payment status through `continuePayment` (see `yuno-flutter-qa-app` `full_sdk_screen.dart`: `startPayment` → OTT listener → `continuePayment`), so the two fixes here restore OTT and status for the standard full/lite/seamless flows.

**Fix.** Re-register each callback per flow by threading the plugin's existing `onTokenUpdated` / `onPaymentStateChange` into the handlers:

- `StartPaymentHandler` / `StartPaymentLiteHandler` → take `onOtt` and pass `callbackOTT = onOtt`.
- `ContinuePaymentHandler` → takes `onState` and passes `callbackPaymentState = onState`.
- `YunoSdkAndroidPlugin.onMethodCall` passes `this::onTokenUpdated` / `this::onPaymentStateChange`.

`startCheckout(...)` is still called in `onCreate` (it also creates the `ActivityResultLauncher`s, which must be registered before the activity is STARTED and cannot be re-created later). The fix only re-establishes the callbacks, not the launchers.

## 🔗 Related Issue

Regression introduced in Flutter SDK `1.0.13` (native Android SDK `2.15.0`). Native source of the change: `clearPaymentFlowCallbacks()` (native ticket CORECM-16334, "fix memory leaks, lifecycle cleanup, and thread safety").

## 📋 Checklist

- [x] ✅ My code follows the code style of this project.
- [x] 📝 I have commented my code, particularly in hard-to-understand areas.
- [x] 🐛 I have fixed all new and existing tests. (No tests call the handlers directly; signature changes are source-compatible. `example/` builds green.)
- [x] 📄 I have updated the documentation accordingly. (`CHANGELOG.md` + `pubspec.yaml` bumped to `1.0.15`.)
- [ ] 📦 This change requires a documentation update.

## 💡 Additional Information

**Validation done**

- ✅ Native signatures for the pinned `android-sdk:2.15.1` expose `callbackOTT` on `startPayment`/`startPaymentLite` and `callbackPaymentState` on `continuePayment`.
- ✅ `example/` builds: `Running Gradle task 'assembleDebug'… ✓ Built build/app/outputs/flutter-apk/app-debug.apk`.
- ⏳ **Recommended before merge:** on-device smoke test of (a) OTT in the headless/lite flow and (b) status after `continuePayment`.

**Residual gap — requires a native-side change (out of scope for this PR).** `startPayment` / `startPaymentLite` do not accept a `callbackPaymentState` parameter, so the payment state delivered through their **direct** activity result (most notably `CANCELED_BY_USER`/error when the user dismisses the sheet before `continuePayment`) cannot be re-registered from the plugin and is lost after `Yuno.init()`. Recommended root fix in `yuno-payments/android-sdk`: add `callbackPaymentState` to `startPayment`/`startPaymentLite` (mirroring `startPaymentSeamlessLite`/`continuePayment`); a follow-up Flutter bump would then pass `this::onPaymentStateChange` there too. Alternatively, stop clearing `startCheckout`-registered callbacks on `injectDependencies()`.

## 🚀 Screenshots (if applicable)

- N/A (no UI changes)

## 🧩 Types of Changes

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🔨 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🛠 Refactoring (change that doesn't add functionality but improves code quality)
- [ ] 📚 Documentation update

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core Android payment bridge behavior relied on for OTT and status delivery; incorrect callback wiring could still break payments, though the change aligns with the native per-call callback contract.
> 
> **Overview**
> Releases **Flutter SDK 1.0.15** and bumps embedded natives to **Android 2.17.1** and **iOS YunoSDK 2.18.0**.
> 
> The functional fix is on **Android**: after native SDK **2.14.0**, `Yuno.initialize()` clears payment-flow callbacks registered in `startCheckout`, so OTT and post-`continuePayment` status never reached Flutter. **`startPayment`**, **`startPaymentLite`**, and **`continuePayment`** now pass `callbackOTT` / `callbackPaymentState` on each call (wired from `YunoSdkAndroidPlugin`’s existing channel handlers).
> 
> The **QA example app** updates iOS bootstrap: **`AppDelegate`** drops `FlutterImplicitEngineDelegate` and registers plugins in `didFinishLaunchingWithOptions`; **`AppFrameworkInfo.plist`** sets **`MinimumOSVersion` 14.0**. Example **`pubspec`** version moves to **1.0.15+1**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8ed948d085cc71edce7e8d95a0270d2c7b50241b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->