### PR TITLE
docs(changelog): summarize 1.0.15 fixes and add native version bumps

### DIFF
--- a/yuno_sdk/CHANGELOG.md
+++ b/yuno_sdk/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## 1.0.15
 
-- fix: Android one-time token (OTT) was not returned to the app after `startPayment`/`startPaymentLite` when running on native Android SDK 2.15.0 or newer
-- fix: Android payment status was not delivered after `continuePayment` when running on native Android SDK 2.15.0 or newer
+- fix: Android one-time token (OTT) and payment status were not delivered to the app when running on native Android SDK 2.15.0 or newer
+- feat: update native Android SDK to 2.17.1 and iOS SDK to 2.18.0
 
 ## 1.0.14
 


### PR DESCRIPTION
## Context
Cleanup of the `CHANGELOG.md` entry for the already-released **1.0.15**, for public docs readability.

## Changes
- Combined the two Android fix entries (OTT not returned + payment status not delivered) into a single, summarized public-facing line.
- Added the native SDK bumps shipped in 1.0.15: **Android 2.17.1** and **iOS 2.18.0**.

## Notes
- Documentation-only change (`yuno_sdk/CHANGELOG.md`). No code or version changes.
- Branched from `master`; targets `master`.

## Testing
- [x] No code impact (changelog text only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to CHANGELOG.md with no code or dependency updates.
> 
> **Overview**
> Updates the **1.0.15** section in `yuno_sdk/CHANGELOG.md` for clearer public release notes.
> 
> The two separate Android fix bullets (`startPayment`/`startPaymentLite` OTT and `continuePayment` status delivery) are **merged** into one line stating that OTT and payment status were not delivered on native Android SDK 2.15.0+.
> 
> A **new** bullet documents the native SDK versions shipped in 1.0.15: Android **2.17.1** and iOS **2.18.0**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6503ab8247717562c42d60f9baa8acf52a3743b4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->