### PR TITLE
chore(release): 1.0.16 - bump native Android SDK to 2.17.2

### DIFF
--- a/yuno-flutter-qa-app/pubspec.yaml
+++ b/yuno-flutter-qa-app/pubspec.yaml
@@ -1,7 +1,7 @@
 name: example
 description: "A new Flutter project."
 publish_to: 'none'
-version: 1.0.15+1
+version: 1.0.16+1
 
 environment:
   sdk: '>=3.5.0 <4.0.0'

--- a/yuno_sdk/CHANGELOG.md
+++ b/yuno_sdk/CHANGELOG.md
@@ -1,38 +1,36 @@
+## 1.0.16
+
+- feat: update native Android SDK to 2.17.2
+
 ## 1.0.15
 
 - fix: Android one-time token (OTT) and payment status were not delivered to the app when running on native Android SDK 2.15.0 or newer
 - feat: update native Android SDK to 2.17.1 and iOS SDK to 2.18.0
 
 ## 1.0.14
-
 - fix: update native Android SDK to 2.15.1
 
 ## 1.0.13
-
 - feat: update native Android SDK to 2.15.0
 - feat: update native iOS SDK to 2.16.0
 
 ## 1.0.12
-
 - feat: update native Android SDK to 2.13.4
 - feat: add cross-platform appearance support via `YunoConfig.appearance`
 - feat: Android font resolution normalizes font names automatically (e.g. "Dancing Script" resolves to "dancingscript" resource)
 - feat: platform-specific configs (`IosConfig.appearance` / `AndroidConfig.appearance`) take priority over shared `YunoConfig.appearance`
 
 ## 1.0.9
-
 - feat: update native Android SDK to 2.13.0
 - feat: update native iOS SDK to 2.14.1
 - feat: add language support for Hindi, Bengali, Malayalam, and Urdu
 
 ## 1.0.5
-
 - fix: Button colors appearing as clear/transparent when not explicitly configured
 - fix: Update yuno_sdk_platform_interface to ^0.7.2
 - fix: Update yuno_sdk_foundation to ^1.0.5
 
 ## 1.0.4
-
 - fix: Update all dependencies to resolve conflicts
 - fix: Update yuno_sdk_core to ^0.4.0
 - fix: Update yuno_sdk_platform_interface to ^0.7.1
@@ -40,42 +38,33 @@
 - fix: Update yuno_sdk_foundation to ^1.0.4
 
 ## 1.0.3
-
 - feat: update native Android SDK to 2.10.0
 - feat: update native iOS SDK to 2.11.1
 - feat: update yuno_sdk_platform_interface to 0.7.0
 
 ## 1.0.2
-
 - feat: update native Android SDK to 2.8.1
 - feat: update native iOS SDK to 2.9.0
 - fix: support Kotlin 2.x and Compose Compiler plugin compatibility on Android
 
 ## 1.0.1
-
 - fix: Update Android native SDK to 2.6.5 (corrects version from 1.0.0)
 
 ## 1.0.0
-
 - feat: upgrade native sdks
 
 ## 0.9.1
-
 - feat: upgrade native sdks
 
 ## 0.8.0
-
-- feat: upgrade native sdks
+ - feat: upgrade native sdks
 
 ## 0.7.1
-
-- fix: upgrade yuno_sdk_platform_interfaces
-
+  - fix: upgrade yuno_sdk_platform_interfaces
 ## 0.7.0
-
 - fix: grammar error
 
-  Instead of:
+    Instead of:
 
   ```dart
     var status = YunoStatus.succeded
@@ -86,50 +75,33 @@
   ```dart
    var status = YunoStatus.succeeded
   ```
-
 - feat: Yuno SDK upgraded
 - feat: Readme Updated
-
 ## 0.6.0
-
 - feat: Yuno SDK upgrade
-
 ## 0.5.1
-
 - fix: Upgrade yuno_sdk_foundation_package
-
 ## 0.5.0
-
 - feat: Yuno SDK Seamless Supported for Android & iOS
 - feat: Code improvements
 - feat: Upgrade Dart SDK
 - fix: Upgrade pro-guard rules for Android
-
 ## 0.4.1
-
 - bugFix: Valuenotifier did not update OTT in IOS
-
 ## 0.4.0
-
 - feat: README improvements
 - feat: Native SDKs upgraded
 - feat: Yuno platform interface testing
-
 ## 0.3.0
-
 - feat: Readme updated
 - feat: Code improvements
 - feat: Coverage 98.7%
 - feat: Native Android and IOS SDK's Upgraded to 1.19.0 version
 - fix: On Android, the ProGuard rules were updated to resolve issues encountered when generating APK's or AAB's in release mode.
-
 ## 0.2.0
-
 - feat: enrollment support for android
 - fix: documentation
-
 ## 0.1.0 - Android & IOS
-
 - feat: Yuno initialization
 - feat: Yuno start checkout
 - feat: Yuno start payment lite

--- a/yuno_sdk/android/build.gradle
+++ b/yuno_sdk/android/build.gradle
@@ -92,7 +92,7 @@ dependencies {
     implementation 'androidx.compose.material:material:1.8.0'
     implementation 'androidx.compose.runtime:runtime:1.8.0'
     implementation "androidx.activity:activity-compose:1.10.1"
-    implementation "com.yuno.payments:android-sdk:2.17.1"
+    implementation "com.yuno.payments:android-sdk:2.17.2"
     implementation "androidx.appcompat:appcompat:1.6.1"
     testImplementation("org.jetbrains.kotlin:kotlin-test")
     testImplementation("org.mockito:mockito-core:5.2.0")

--- a/yuno_sdk/android/src/main/kotlin/com/yuno_flutter/yuno_sdk_android/YunoSdkAndroidPlugin.kt
+++ b/yuno_sdk/android/src/main/kotlin/com/yuno_flutter/yuno_sdk_android/YunoSdkAndroidPlugin.kt
@@ -88,9 +88,7 @@ If you continue to have trouble, follow this discussion to get some support """,
                 init.handler(
                     call = call,
                     result = result,
-                    context = context,
-                    activity = activity,
-                    onOtt = this::onTokenUpdated,
+                    context = context, activity,
                 )
             }
             Key.startPaymentLite -> {
@@ -99,8 +97,7 @@ If you continue to have trouble, follow this discussion to get some support """,
                         call = call,
                         result = result,
                         context = context,
-                        activity = activity,
-                        onOtt = this::onTokenUpdated,
+                        activity = activity
                     )
             }
             Key.continuePayment -> {
@@ -109,8 +106,7 @@ If you continue to have trouble, follow this discussion to get some support """,
                     call = call,
                     result = result,
                     context = context,
-                    activity = activity,
-                    onState = this::onPaymentStateChange,
+                    activity = activity
                 )
             }
             Key.enrollmentPayment -> {

--- a/yuno_sdk/android/src/main/kotlin/com/yuno_flutter/yuno_sdk_android/features/continue_payment/method_channel/ContinuePaymentHandler.kt
+++ b/yuno_sdk/android/src/main/kotlin/com/yuno_flutter/yuno_sdk_android/features/continue_payment/method_channel/ContinuePaymentHandler.kt
@@ -13,18 +13,17 @@ class ContinuePaymentHandler {
         private const val TAG = "ContinuePaymentHandler"
     }
     
-    fun handler(call: MethodCall, result: Result, context: Context, activity: FlutterFragmentActivity, onState: (String?, String?) -> Unit){
+    fun handler(call: MethodCall, result: Result, context: Context, activity: FlutterFragmentActivity){
        try {
            val showPaymentStatus = call.arguments<Boolean>() ?: true
-
+           
            // Get current saved value before updating
            val previousShowPaymentStatus = PaymentConfig.getShowPaymentStatus()
-
+           
            // Save the showPaymentStatus value in memory for later use in deeplink handling
            PaymentConfig.setShowPaymentStatus(showPaymentStatus)
-
-           // Re-register the payment-state callback per call: Yuno.init() clears it via clearPaymentFlowCallbacks() (native SDK >= 2.14.0)
-           activity.continuePayment(showPaymentStatus = showPaymentStatus, callbackPaymentState = onState)
+           
+           activity.continuePayment(showPaymentStatus = showPaymentStatus)
        } catch (e:Exception){
            result.error("4",e.message ?: "Unexpected Error",e.cause)
        }

--- a/yuno_sdk/android/src/main/kotlin/com/yuno_flutter/yuno_sdk_android/features/start_payment/method_channel/StartPaymentHandler.kt
+++ b/yuno_sdk/android/src/main/kotlin/com/yuno_flutter/yuno_sdk_android/features/start_payment/method_channel/StartPaymentHandler.kt
@@ -11,7 +11,7 @@ import io.flutter.plugin.common.MethodCall
 import io.flutter.plugin.common.MethodChannel.Result
 
 class StartPaymentHandler {
-    fun handler(call: MethodCall, result: Result, context: Context, activity: FlutterFragmentActivity, onOtt: (String?) -> Unit){
+    fun handler(call: MethodCall, result: Result, context: Context, activity: FlutterFragmentActivity){
         try {
             val argument = call.arguments<Map<String, Any>>()
             val model = argument?.toStartPayment()
@@ -21,8 +21,7 @@ class StartPaymentHandler {
             // Save the showPaymentStatus for potential deeplink handling
             PaymentConfig.setShowPaymentStatus(showPaymentStatus)
             Yuno.setPlatform(YunoPlatform.FLUTTER)
-            // Re-register the OTT callback per payment: Yuno.init() clears it via clearPaymentFlowCallbacks() (native SDK >= 2.14.0)
-            activity.startPayment(showPaymentStatus = showPaymentStatus, callbackOTT = onOtt)
+            activity.startPayment(showPaymentStatus = showPaymentStatus)
         } catch (e: Exception) {
             return result.error("SOMETHING_WENT_WRONG", "Failure", e.message)
         }

--- a/yuno_sdk/android/src/main/kotlin/com/yuno_flutter/yuno_sdk_android/features/start_payment_lite/method_channels/StartPaymentLiteHandler.kt
+++ b/yuno_sdk/android/src/main/kotlin/com/yuno_flutter/yuno_sdk_android/features/start_payment_lite/method_channels/StartPaymentLiteHandler.kt
@@ -12,7 +12,7 @@ import io.flutter.plugin.common.MethodCall
 import io.flutter.plugin.common.MethodChannel.Result
 
 class StartPaymentLiteHandler {
-    fun handler(call: MethodCall, result: Result, context: Context, activity: FlutterFragmentActivity, onOtt: (String?) -> Unit){
+    fun handler(call: MethodCall, result: Result, context: Context, activity: FlutterFragmentActivity){
         try {
             val argument = call.arguments<Map<String, Any>>()
             val either = argument?.toStartPaymentLite()
@@ -26,14 +26,12 @@ class StartPaymentLiteHandler {
                     countryCode = model.countryCode
                 )
                 Yuno.setPlatform(YunoPlatform.FLUTTER)
-                // Re-register the OTT callback per payment: Yuno.init() clears it via clearPaymentFlowCallbacks() (native SDK >= 2.14.0)
                 activity.startPaymentLite(
                     paymentSelected = PaymentSelected(
                         paymentMethodType = model.paymentMethodSelected.paymentMethodType,
                         vaultedToken = model.paymentMethodSelected.vaultedToken,
                     ),
-                    showPaymentStatus = model.showPaymentStatus,
-                    callbackOTT = onOtt,
+                    showPaymentStatus = model.showPaymentStatus
                 )
             }?.onFailure { exception ->  return result.error(
                 "5",

--- a/yuno_sdk/ios/yuno.podspec
+++ b/yuno_sdk/ios/yuno.podspec
@@ -4,7 +4,7 @@
 #
 Pod::Spec.new do |s|
   s.name             = 'yuno'
-  s.version          = '1.0.15'
+  s.version          = '1.0.16'
   s.summary          = 'A Yuno project'
   s.description      = <<-DESC
 A new Flutter plugin project.

--- a/yuno_sdk/pubspec.yaml
+++ b/yuno_sdk/pubspec.yaml
@@ -1,10 +1,10 @@
 name: yuno
 description: "Yuno Flutter SDK empowers you to create seamless payment experiences in your native Android and iOS apps built with Flutter. "
-version: 1.0.15
+version: 1.0.16
 homepage: https://www.y.uno/
 environment:
-  sdk: ">=3.6.0 <4.0.0"
-  flutter: ">=3.3.0"
+  sdk: '>=3.6.0 <4.0.0'
+  flutter: '>=3.3.0'
 
 dependencies:
   flutter:


### PR DESCRIPTION
## Context
Release 1.0.16. Bumps the native Android SDK to **2.17.2** and sets the package / QA app version to **1.0.16**. iOS native (2.18.0) already shipped in 1.0.15.

## Changes
- `yuno_sdk/android/build.gradle` — Android native `2.17.1` -> `2.17.2`
- `yuno_sdk/pubspec.yaml` — version `1.0.16`
- `yuno_sdk/ios/yuno.podspec` — `s.version` `1.0.16` (YunoSDK stays 2.18.0)
- `yuno-flutter-qa-app/pubspec.yaml` — version `1.0.16+1`
- `yuno_sdk/CHANGELOG.md` — add 1.0.16 entry (+ restore 1.0.15 entry)

## ⚠️ IMPORTANT — this PR REVERTS the 1.0.15 OTT/status fix
This branch resets the Android Kotlin handlers to the **1.0.14 baseline**, which **removes** the 1.0.15 callback re-registration fix (`onOtt` / `callbackPaymentState` re-registration in `StartPaymentHandler`, `StartPaymentLiteHandler`, `ContinuePaymentHandler`, `YunoSdkAndroidPlugin`).

Consequence: with native Android >= 2.15.0, the **one-time token (OTT) and payment status will NOT be delivered to the app again** (the exact bug 1.0.15 fixed) — now on top of native 2.17.2.

If 1.0.16 is meant to be **1.0.15 + Android 2.17.2**, the handler changes must be re-applied before merge. Flagging explicitly per request to open the PR as-is.

## Testing
- [x] Android native 2.17.2 resolves (gradle dependency check)
- [ ] Manual: confirm intended behavior re: OTT delivery

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Payment integration changes remove callback re-registration on Android while shipping a newer native SDK, reintroducing the OTT/payment-status delivery bug fixed in 1.0.15 for native ≥ 2.15.0.
> 
> **Overview**
> **Release 1.0.16** bumps package versions (`yuno_sdk`, iOS podspec, QA app) and updates the Android Gradle dependency from **2.17.1** to **2.17.2**, with a matching **CHANGELOG** entry.
> 
> On Android Kotlin bridge code, this PR **drops per-call OTT and payment-state callback wiring** from `StartPaymentHandler`, `StartPaymentLiteHandler`, and `ContinuePaymentHandler` (and stops passing `onOtt` / `onState` from `YunoSdkAndroidPlugin`). Those flows now call `startPayment`, `startPaymentLite`, and `continuePayment` with only `showPaymentStatus` (and related args), instead of re-registering `callbackOTT` / `callbackPaymentState` on each invocation—the pattern **1.0.15** added for native Android **≥ 2.15.0** when `Yuno.init()` clears payment callbacks.
> 
> **Reviewers should treat this as a likely regression**: OTT and payment status may again fail to reach Flutter on `startPayment` / lite / `continuePayment` paths while still on native **2.17.2**, unless the native SDK no longer requires per-call re-registration.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8314ac15a89961bd42ef4c74e57824b165ecf104. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->