### PR TITLE
chore(release): 1.0.17 — bump native Android SDK to 2.17.3

### DIFF
--- a/yuno-flutter-qa-app/pubspec.yaml
+++ b/yuno-flutter-qa-app/pubspec.yaml
@@ -1,7 +1,7 @@
 name: example
 description: "A new Flutter project."
 publish_to: 'none'
-version: 1.0.16+1
+version: 1.0.17+1
 
 environment:
   sdk: '>=3.5.0 <4.0.0'

--- a/yuno-flutter-qa-app/scripts/slack_changelog_summary.sh
+++ b/yuno-flutter-qa-app/scripts/slack_changelog_summary.sh
@@ -47,14 +47,17 @@ CHANGELOG_SUMMARY=$(cat "$SUMMARY_FILE")
 print_message $GREEN "📝 Changelog summary generated successfully"
 SLACK_SUMMARY=$(echo "$CHANGELOG_SUMMARY" | sed 's/\*\*/*/g')
 
-SLACK_CHANNEL="new-releases-product"
+SLACK_CHANNELS=("new-releases-product" "r5_yuno")
 MESSAGE="New Flutter SDK version released: $VERSION_BITRISE"
 
 ESCAPED_SUMMARY=$(echo "$SLACK_SUMMARY" | sed 's/"/\\"/g; s/$/\\n/' | tr -d '\n')
 
-print_message $BLUE "📤 Sending changelog summary to Slack..."
+FAILED_CHANNELS=()
 
-SLACK_PAYLOAD=$(cat <<EOF
+for SLACK_CHANNEL in "${SLACK_CHANNELS[@]}"; do
+    print_message $BLUE "📤 Sending changelog summary to #$SLACK_CHANNEL..."
+
+    SLACK_PAYLOAD=$(cat <<EOF
 {
   "channel": "$SLACK_CHANNEL",
   "text": "$MESSAGE",
@@ -70,16 +73,22 @@ SLACK_PAYLOAD=$(cat <<EOF
 EOF
 )
 
-RESPONSE=$(curl -s -X POST https://slack.com/api/chat.postMessage \
-    -H "Authorization: Bearer $SLACK_BOTH_API_TOKEN" \
-    -H "Content-type: application/json" \
-    --data "$SLACK_PAYLOAD")
+    RESPONSE=$(curl -s -X POST https://slack.com/api/chat.postMessage \
+        -H "Authorization: Bearer $SLACK_BOTH_API_TOKEN" \
+        -H "Content-type: application/json" \
+        --data "$SLACK_PAYLOAD")
 
-if echo "$RESPONSE" | grep -q '"ok":true'; then
-    print_message $GREEN "✅ Changelog summary sent to Slack successfully!"
-else
-    print_message $RED "❌ Failed to send message to Slack"
-    print_message $YELLOW "Response: $RESPONSE"
+    if echo "$RESPONSE" | grep -q '"ok":true'; then
+        print_message $GREEN "✅ Changelog summary sent to #$SLACK_CHANNEL successfully!"
+    else
+        print_message $RED "❌ Failed to send message to #$SLACK_CHANNEL"
+        print_message $YELLOW "Response: $RESPONSE"
+        FAILED_CHANNELS+=("$SLACK_CHANNEL")
+    fi
+done
+
+if [ ${#FAILED_CHANNELS[@]} -ne 0 ]; then
+    print_message $RED "❌ Failed to send message to: ${FAILED_CHANNELS[*]}"
     exit 1
 fi
 

--- a/yuno_sdk/CHANGELOG.md
+++ b/yuno_sdk/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.0.17
+
+- feat: update native Android SDK to 2.17.3
+- docs: add public repository and issue tracker links to pub.dev page
+
 ## 1.0.16
 
 - feat: update native Android SDK to 2.17.2

--- a/yuno_sdk/android/build.gradle
+++ b/yuno_sdk/android/build.gradle
@@ -92,7 +92,7 @@ dependencies {
     implementation 'androidx.compose.material:material:1.8.0'
     implementation 'androidx.compose.runtime:runtime:1.8.0'
     implementation "androidx.activity:activity-compose:1.10.1"
-    implementation "com.yuno.payments:android-sdk:2.17.2"
+    implementation "com.yuno.payments:android-sdk:2.17.3"
     implementation "androidx.appcompat:appcompat:1.6.1"
     testImplementation("org.jetbrains.kotlin:kotlin-test")
     testImplementation("org.mockito:mockito-core:5.2.0")

--- a/yuno_sdk/pubspec.yaml
+++ b/yuno_sdk/pubspec.yaml
@@ -1,7 +1,9 @@
 name: yuno
 description: "Yuno Flutter SDK empowers you to create seamless payment experiences in your native Android and iOS apps built with Flutter. "
-version: 1.0.16
+version: 1.0.17
 homepage: https://www.y.uno/
+repository: https://github.com/yuno-payments/yuno-sdk-flutter
+issue_tracker: https://github.com/yuno-payments/yuno-sdk-flutter/issues
 environment:
   sdk: '>=3.6.0 <4.0.0'
   flutter: '>=3.3.0'


### PR DESCRIPTION
## Context
Release preparation for version 1.0.17 of the Yuno Flutter SDK.

## Native version bump
Bump the native Android SDK pin `2.17.2` -> `2.17.3` in `yuno_sdk/android/build.gradle`. (Note: 2.17.3 is not yet published — pinned ahead per request.)

## Version bumps
- `yuno` package: `1.0.16` -> `1.0.17` (`yuno_sdk/pubspec.yaml`)
- QA app: `1.0.16+1` -> `1.0.17+1` (`yuno-flutter-qa-app/pubspec.yaml`)

## pub.dev repository link
Add `repository` and `issue_tracker` links to `yuno_sdk/pubspec.yaml` so the public GitHub repo appears on the pub.dev package page.

## Slack notification
`slack_changelog_summary.sh` now notifies both `new-releases-product` and `r5_yuno` when a release changelog is published. Failures are collected per-channel so one bad channel does not block the other.

## Notes
- The bot behind `SLACK_BOTH_API_TOKEN` must be invited to `#r5_yuno`, otherwise Slack returns `not_in_channel`.

## Testing
- [ ] Verify pub.dev shows the repository link after publishing 1.0.17
- [ ] Smoke-test example/ and QA app on Android with native 2.17.3 (once published)
- [ ] Confirm Slack notification lands in both channels

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Pins a newer native Android payments SDK (build may fail until 2.17.3 is published) and changes release notification behavior for Slack.
> 
> **Overview**
> **Release 1.0.17** bumps the Flutter `yuno` package and QA example app, pins the embedded **native Android SDK** from `2.17.2` to **`2.17.3`** in `yuno_sdk/android/build.gradle`, and documents the release in `CHANGELOG.md`.
> 
> **pub.dev** metadata now includes **`repository`** and **`issue_tracker`** URLs on `yuno_sdk/pubspec.yaml` so the GitHub repo and issues link show on the package page.
> 
> **Release Slack automation** posts the changelog summary to **`new-releases-product`** and **`r5_yuno`**, reporting success per channel and exiting with failure only if any channel post fails (one channel failing no longer short-circuits the other).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f19c968c547e694b3a4ffcbdad2587f918dfe199. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->